### PR TITLE
Upgraded babel-options and babel-plugin-tester packages

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1,6 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default 1`] = `
+exports[`class 1`] = `
+"
+class a {}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports: []
+  imports: []
+  statements:
+    - ClassDeclaration (1:0,1:10)
+        body: ClassBody (1:8,1:10)
+          body: []
+        id: Identifier (1:6,1:7)
+          name: 'a'
+        superClass: null
+\`;
+"
+`;
+
+exports[`default 1`] = `
 "
 import a from \\"b\\";
 
@@ -26,7 +46,79 @@ import a from \\"b\\";
 "
 `;
 
-exports[`1. default binding 1`] = `
+exports[`default and named 1`] = `
+"
+import a, {b} from \\"c\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports: []
+  imports:
+    -
+        external: 'default'
+        kind: 'value'
+        loc:
+          end:
+            column: 8
+            line: 1
+          start:
+            column: 7
+            line: 1
+        local: 'a'
+        source: 'c'
+    -
+        external: 'b'
+        kind: 'value'
+        loc:
+          end:
+            column: 12
+            line: 1
+          start:
+            column: 11
+            line: 1
+        local: 'b'
+        source: 'c'
+  statements: []
+\`;
+"
+`;
+
+exports[`default array 1`] = `
+"
+export default [a];
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'default'
+        loc:
+          end:
+            column: 19
+            line: 1
+          start:
+            column: 0
+            line: 1
+        local: '_default'
+  imports: []
+  statements:
+    - VariableDeclaration (1:15,1:18)
+        declarations:
+          - VariableDeclarator (1:15,1:18)
+              id: Identifier
+                name: '_default'
+              init: ArrayExpression (1:15,1:18)
+                elements:
+                  - Identifier (1:16,1:17)
+                      name: 'a'
+        kind: 'const'
+\`;
+"
+`;
+
+exports[`default binding 1`] = `
 "
 export default a;
 
@@ -50,21 +142,249 @@ export default a;
 "
 `;
 
-exports[`1. empty 1`] = `
+exports[`default boolean 1`] = `
 "
-;
+export default true;
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 \`
-  exports: []
+  exports:
+    -
+        external: 'default'
+        loc:
+          end:
+            column: 20
+            line: 1
+          start:
+            column: 0
+            line: 1
+        local: '_default'
   imports: []
-  statements: []
+  statements:
+    - VariableDeclaration (1:15,1:19)
+        declarations:
+          - VariableDeclarator (1:15,1:19)
+              id: Identifier
+                name: '_default'
+              init: BooleanLiteral (1:15,1:19)
+                value: true
+        kind: 'const'
 \`;
 "
 `;
 
-exports[`2. default object 1`] = `
+exports[`default class 1`] = `
+"
+export default class {}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'default'
+        loc:
+          end:
+            column: 23
+            line: 1
+          start:
+            column: 0
+            line: 1
+        local: '_default'
+  imports: []
+  statements:
+    - VariableDeclaration (1:15,1:23)
+        declarations:
+          - VariableDeclarator (1:15,1:23)
+              id: Identifier
+                name: '_default'
+              init: ClassExpression (1:15,1:23)
+                body: ClassBody (1:21,1:23)
+                  body: []
+                id: null
+                superClass: null
+        kind: 'const'
+\`;
+"
+`;
+
+exports[`default expression 1`] = `
+"
+export default a ? b : c;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'default'
+        loc:
+          end:
+            column: 25
+            line: 1
+          start:
+            column: 0
+            line: 1
+        local: '_default'
+  imports: []
+  statements:
+    - VariableDeclaration (1:15,1:24)
+        declarations:
+          - VariableDeclarator (1:15,1:24)
+              id: Identifier
+                name: '_default'
+              init: ConditionalExpression (1:15,1:24)
+                alternate: Identifier (1:23,1:24)
+                  name: 'c'
+                consequent: Identifier (1:19,1:20)
+                  name: 'b'
+                test: Identifier (1:15,1:16)
+                  name: 'a'
+        kind: 'const'
+\`;
+"
+`;
+
+exports[`default function 1`] = `
+"
+export default function() {}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'default'
+        loc:
+          end:
+            column: 28
+            line: 1
+          start:
+            column: 0
+            line: 1
+        local: '_default'
+  imports: []
+  statements:
+    - VariableDeclaration (1:15,1:28)
+        declarations:
+          - VariableDeclarator (1:15,1:28)
+              id: Identifier
+                name: '_default'
+              init: FunctionExpression (1:15,1:28)
+                async: false
+                body: BlockStatement (1:26,1:28)
+                  body: []
+                  directives: []
+                expression: false
+                generator: false
+                id: null
+                params: []
+        kind: 'const'
+\`;
+"
+`;
+
+exports[`default named class 1`] = `
+"
+export default class a {}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'default'
+        loc:
+          end:
+            column: 25
+            line: 1
+          start:
+            column: 0
+            line: 1
+        local: 'a'
+  imports: []
+  statements:
+    - ClassDeclaration (1:15,1:25)
+        body: ClassBody (1:23,1:25)
+          body: []
+        id: Identifier (1:21,1:22)
+          name: 'a'
+        superClass: null
+\`;
+"
+`;
+
+exports[`default named function 1`] = `
+"
+export default function a() {}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'default'
+        loc:
+          end:
+            column: 30
+            line: 1
+          start:
+            column: 0
+            line: 1
+        local: 'a'
+  imports: []
+  statements:
+    - FunctionDeclaration (1:15,1:30)
+        async: false
+        body: BlockStatement (1:28,1:30)
+          body: []
+          directives: []
+        expression: false
+        generator: false
+        id: Identifier (1:24,1:25)
+          name: 'a'
+        params: []
+\`;
+"
+`;
+
+exports[`default number 1`] = `
+"
+export default 1;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'default'
+        loc:
+          end:
+            column: 17
+            line: 1
+          start:
+            column: 0
+            line: 1
+        local: '_default'
+  imports: []
+  statements:
+    - VariableDeclaration (1:15,1:16)
+        declarations:
+          - VariableDeclarator (1:15,1:16)
+              id: Identifier
+                name: '_default'
+              init: NumericLiteral (1:15,1:16)
+                extra:
+                  raw: '1'
+                  rawValue: 1
+                value: 1
+        kind: 'const'
+\`;
+"
+`;
+
+exports[`default object 1`] = `
 "
 export default {a};
 
@@ -107,256 +427,7 @@ export default {a};
 "
 `;
 
-exports[`2. named 1`] = `
-"
-import {a} from \\"b\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports:
-    -
-        external: 'a'
-        kind: 'value'
-        loc:
-          end:
-            column: 9
-            line: 1
-          start:
-            column: 8
-            line: 1
-        local: 'a'
-        source: 'b'
-  statements: []
-\`;
-"
-`;
-
-exports[`2. variable 1`] = `
-"
-var a;
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports: []
-  statements:
-    - VariableDeclaration (1:4,1:5)
-        declarations:
-          - VariableDeclarator (1:4,1:5)
-              id: Identifier (1:4,1:5)
-                name: 'a'
-              init: null
-        kind: 'var'
-\`;
-"
-`;
-
-exports[`3. default array 1`] = `
-"
-export default [a];
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'default'
-        loc:
-          end:
-            column: 19
-            line: 1
-          start:
-            column: 0
-            line: 1
-        local: '_default'
-  imports: []
-  statements:
-    - VariableDeclaration (1:15,1:18)
-        declarations:
-          - VariableDeclarator (1:15,1:18)
-              id: Identifier
-                name: '_default'
-              init: ArrayExpression (1:15,1:18)
-                elements:
-                  - Identifier (1:16,1:17)
-                      name: 'a'
-        kind: 'const'
-\`;
-"
-`;
-
-exports[`3. function 1`] = `
-"
-function a() {}
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports: []
-  statements:
-    - FunctionDeclaration (1:0,1:15)
-        async: false
-        body: BlockStatement (1:13,1:15)
-          body: []
-          directives: []
-        expression: false
-        generator: false
-        id: Identifier (1:9,1:10)
-          name: 'a'
-        params: []
-\`;
-"
-`;
-
-exports[`3. named renamed 1`] = `
-"
-import {a as b} from \\"c\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports:
-    -
-        external: 'a'
-        kind: 'value'
-        loc:
-          end:
-            column: 14
-            line: 1
-          start:
-            column: 8
-            line: 1
-        local: 'b'
-        source: 'c'
-  statements: []
-\`;
-"
-`;
-
-exports[`4. class 1`] = `
-"
-class a {}
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports: []
-  statements:
-    - ClassDeclaration (1:0,1:10)
-        body: ClassBody (1:8,1:10)
-          body: []
-        id: Identifier (1:6,1:7)
-          name: 'a'
-        superClass: null
-\`;
-"
-`;
-
-exports[`4. default number 1`] = `
-"
-export default 1;
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'default'
-        loc:
-          end:
-            column: 17
-            line: 1
-          start:
-            column: 0
-            line: 1
-        local: '_default'
-  imports: []
-  statements:
-    - VariableDeclaration (1:15,1:16)
-        declarations:
-          - VariableDeclarator (1:15,1:16)
-              id: Identifier
-                name: '_default'
-              init: NumericLiteral (1:15,1:16)
-                extra:
-                  raw: '1'
-                  rawValue: 1
-                value: 1
-        kind: 'const'
-\`;
-"
-`;
-
-exports[`4. namespace 1`] = `
-"
-import * as a from \\"b\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports:
-    -
-        kind: 'value'
-        loc:
-          end:
-            column: 13
-            line: 1
-          start:
-            column: 7
-            line: 1
-        local: 'a'
-        source: 'b'
-  statements: []
-\`;
-"
-`;
-
-exports[`5. default and named 1`] = `
-"
-import a, {b} from \\"c\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports:
-    -
-        external: 'default'
-        kind: 'value'
-        loc:
-          end:
-            column: 8
-            line: 1
-          start:
-            column: 7
-            line: 1
-        local: 'a'
-        source: 'c'
-    -
-        external: 'b'
-        kind: 'value'
-        loc:
-          end:
-            column: 12
-            line: 1
-          start:
-            column: 11
-            line: 1
-        local: 'b'
-        source: 'c'
-  statements: []
-\`;
-"
-`;
-
-exports[`5. default string 1`] = `
+exports[`default string 1`] = `
 "
 export default \\"a\\";
 
@@ -391,67 +462,7 @@ export default \\"a\\";
 "
 `;
 
-exports[`5. variable multiple 1`] = `
-"
-var a, b;
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports: []
-  statements:
-    - VariableDeclaration (1:4,1:5)
-        declarations:
-          - VariableDeclarator (1:4,1:5)
-              id: Identifier (1:4,1:5)
-                name: 'a'
-              init: null
-        kind: 'var'
-    - VariableDeclaration (1:7,1:8)
-        declarations:
-          - VariableDeclarator (1:7,1:8)
-              id: Identifier (1:7,1:8)
-                name: 'b'
-              init: null
-        kind: 'var'
-\`;
-"
-`;
-
-exports[`6. default boolean 1`] = `
-"
-export default true;
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'default'
-        loc:
-          end:
-            column: 20
-            line: 1
-          start:
-            column: 0
-            line: 1
-        local: '_default'
-  imports: []
-  statements:
-    - VariableDeclaration (1:15,1:19)
-        declarations:
-          - VariableDeclarator (1:15,1:19)
-              id: Identifier
-                name: '_default'
-              init: BooleanLiteral (1:15,1:19)
-                value: true
-        kind: 'const'
-\`;
-"
-`;
-
-exports[`6. effect 1`] = `
+exports[`effect 1`] = `
 "
 import \\"c\\";
 
@@ -474,7 +485,21 @@ import \\"c\\";
 "
 `;
 
-exports[`6. for 1`] = `
+exports[`empty 1`] = `
+"
+;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports: []
+  imports: []
+  statements: []
+\`;
+"
+`;
+
+exports[`for 1`] = `
 "
 for (;;) {}
 
@@ -495,9 +520,32 @@ for (;;) {}
 "
 `;
 
-exports[`7. default expression 1`] = `
+exports[`from all 1`] = `
 "
-export default a ? b : c;
+export * from \\"b\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        loc:
+          end:
+            column: 18
+            line: 1
+          start:
+            column: 0
+            line: 1
+        source: 'b'
+  imports: []
+  statements: []
+\`;
+"
+`;
+
+exports[`from default 1`] = `
+"
+export default from \\"b\\";
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -507,32 +555,180 @@ export default a ? b : c;
         external: 'default'
         loc:
           end:
-            column: 25
+            column: 14
             line: 1
           start:
-            column: 0
+            column: 7
             line: 1
-        local: '_default'
+        local: 'default'
+        source: 'b'
   imports: []
-  statements:
-    - VariableDeclaration (1:15,1:24)
-        declarations:
-          - VariableDeclarator (1:15,1:24)
-              id: Identifier
-                name: '_default'
-              init: ConditionalExpression (1:15,1:24)
-                alternate: Identifier (1:23,1:24)
-                  name: 'c'
-                consequent: Identifier (1:19,1:20)
-                  name: 'b'
-                test: Identifier (1:15,1:16)
-                  name: 'a'
-        kind: 'const'
+  statements: []
 \`;
 "
 `;
 
-exports[`7. import type 1`] = `
+exports[`from default renamed 1`] = `
+"
+export a from \\"b\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'a'
+        loc:
+          end:
+            column: 8
+            line: 1
+          start:
+            column: 7
+            line: 1
+        local: 'a'
+        source: 'b'
+  imports: []
+  statements: []
+\`;
+"
+`;
+
+exports[`from named 1`] = `
+"
+export {a} from \\"b\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'a'
+        loc:
+          end:
+            column: 9
+            line: 1
+          start:
+            column: 8
+            line: 1
+        local: 'a'
+        source: 'b'
+  imports: []
+  statements: []
+\`;
+"
+`;
+
+exports[`from named default renamed 1`] = `
+"
+export {default as a} from \\"b\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'a'
+        loc:
+          end:
+            column: 20
+            line: 1
+          start:
+            column: 8
+            line: 1
+        local: 'default'
+        source: 'b'
+  imports: []
+  statements: []
+\`;
+"
+`;
+
+exports[`from named multiple 1`] = `
+"
+export {a, b} from \\"b\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'a'
+        loc:
+          end:
+            column: 9
+            line: 1
+          start:
+            column: 8
+            line: 1
+        local: 'a'
+        source: 'b'
+    -
+        external: 'b'
+        loc:
+          end:
+            column: 12
+            line: 1
+          start:
+            column: 11
+            line: 1
+        local: 'b'
+        source: 'b'
+  imports: []
+  statements: []
+\`;
+"
+`;
+
+exports[`from named renamed 1`] = `
+"
+export {a as b} from \\"c\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'b'
+        loc:
+          end:
+            column: 14
+            line: 1
+          start:
+            column: 8
+            line: 1
+        local: 'a'
+        source: 'c'
+  imports: []
+  statements: []
+\`;
+"
+`;
+
+exports[`function 1`] = `
+"
+function a() {}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports: []
+  imports: []
+  statements:
+    - FunctionDeclaration (1:0,1:15)
+        async: false
+        body: BlockStatement (1:13,1:15)
+          body: []
+          directives: []
+        expression: false
+        generator: false
+        id: Identifier (1:9,1:10)
+          name: 'a'
+        params: []
+\`;
+"
+`;
+
+exports[`import type 1`] = `
 "
 import type a from \\"b\\";
 
@@ -558,149 +754,7 @@ import type a from \\"b\\";
 "
 `;
 
-exports[`7. while 1`] = `
-"
-while (a) {}
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports: []
-  statements:
-    - WhileStatement (1:0,1:12)
-        body: BlockStatement (1:10,1:12)
-          body: []
-          directives: []
-        test: Identifier (1:7,1:8)
-          name: 'a'
-\`;
-"
-`;
-
-exports[`8. default named function 1`] = `
-"
-export default function a() {}
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'default'
-        loc:
-          end:
-            column: 30
-            line: 1
-          start:
-            column: 0
-            line: 1
-        local: 'a'
-  imports: []
-  statements:
-    - FunctionDeclaration (1:15,1:30)
-        async: false
-        body: BlockStatement (1:28,1:30)
-          body: []
-          directives: []
-        expression: false
-        generator: false
-        id: Identifier (1:24,1:25)
-          name: 'a'
-        params: []
-\`;
-"
-`;
-
-exports[`8. import typeof 1`] = `
-"
-import typeof a from \\"b\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports:
-    -
-        external: 'a'
-        kind: 'typeof'
-        loc:
-          end:
-            column: 15
-            line: 1
-          start:
-            column: 14
-            line: 1
-        local: 'a'
-        source: 'b'
-  statements: []
-\`;
-"
-`;
-
-exports[`8. type alias 1`] = `
-"
-type a = {};
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports: []
-  imports: []
-  statements:
-    - TypeAlias (1:0,1:12)
-        id: Identifier (1:5,1:6)
-          name: 'a'
-        right: ObjectTypeAnnotation (1:9,1:11)
-          callProperties: []
-          exact: false
-          indexers: []
-          properties: []
-        typeParameters: null
-\`;
-"
-`;
-
-exports[`9. default function 1`] = `
-"
-export default function() {}
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'default'
-        loc:
-          end:
-            column: 28
-            line: 1
-          start:
-            column: 0
-            line: 1
-        local: '_default'
-  imports: []
-  statements:
-    - VariableDeclaration (1:15,1:28)
-        declarations:
-          - VariableDeclarator (1:15,1:28)
-              id: Identifier
-                name: '_default'
-              init: FunctionExpression (1:15,1:28)
-                async: false
-                body: BlockStatement (1:26,1:28)
-                  body: []
-                  directives: []
-                expression: false
-                generator: false
-                id: null
-                params: []
-        kind: 'const'
-\`;
-"
-`;
-
-exports[`9. import type inner 1`] = `
+exports[`import type inner 1`] = `
 "
 import {type a} from \\"b\\";
 
@@ -726,62 +780,33 @@ import {type a} from \\"b\\";
 "
 `;
 
-exports[`9. interface 1`] = `
+exports[`import typeof 1`] = `
 "
-interface a {}
+import typeof a from \\"b\\";
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 \`
   exports: []
-  imports: []
-  statements:
-    - InterfaceDeclaration (1:0,1:14)
-        body: ObjectTypeAnnotation (1:12,1:14)
-          callProperties: []
-          exact: false
-          indexers: []
-          properties: []
-        extends: []
-        id: Identifier (1:10,1:11)
-          name: 'a'
-        mixins: []
-        typeParameters: null
-\`;
-"
-`;
-
-exports[`10. default named class 1`] = `
-"
-export default class a {}
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
+  imports:
     -
-        external: 'default'
+        external: 'a'
+        kind: 'typeof'
         loc:
           end:
-            column: 25
+            column: 15
             line: 1
           start:
-            column: 0
+            column: 14
             line: 1
         local: 'a'
-  imports: []
-  statements:
-    - ClassDeclaration (1:15,1:25)
-        body: ClassBody (1:23,1:25)
-          body: []
-        id: Identifier (1:21,1:22)
-          name: 'a'
-        superClass: null
+        source: 'b'
+  statements: []
 \`;
 "
 `;
 
-exports[`10. import typeof inner 1`] = `
+exports[`import typeof inner 1`] = `
 "
 import {typeof a} from \\"b\\";
 
@@ -807,42 +832,7 @@ import {typeof a} from \\"b\\";
 "
 `;
 
-exports[`11. default class 1`] = `
-"
-export default class {}
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'default'
-        loc:
-          end:
-            column: 23
-            line: 1
-          start:
-            column: 0
-            line: 1
-        local: '_default'
-  imports: []
-  statements:
-    - VariableDeclaration (1:15,1:23)
-        declarations:
-          - VariableDeclarator (1:15,1:23)
-              id: Identifier
-                name: '_default'
-              init: ClassExpression (1:15,1:23)
-                body: ClassBody (1:21,1:23)
-                  body: []
-                id: null
-                superClass: null
-        kind: 'const'
-\`;
-"
-`;
-
-exports[`11. import value/type/typeof inner 1`] = `
+exports[`import value/type/typeof inner 1`] = `
 "
 import {a, type b, typeof c} from \\"b\\";
 
@@ -892,9 +882,60 @@ import {a, type b, typeof c} from \\"b\\";
 "
 `;
 
-exports[`12. named specifier 1`] = `
+exports[`interface 1`] = `
 "
-export {a}
+interface a {}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports: []
+  imports: []
+  statements:
+    - InterfaceDeclaration (1:0,1:14)
+        body: ObjectTypeAnnotation (1:12,1:14)
+          callProperties: []
+          exact: false
+          indexers: []
+          properties: []
+        extends: []
+        id: Identifier (1:10,1:11)
+          name: 'a'
+        mixins: []
+        typeParameters: null
+\`;
+"
+`;
+
+exports[`named 1`] = `
+"
+import {a} from \\"b\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports: []
+  imports:
+    -
+        external: 'a'
+        kind: 'value'
+        loc:
+          end:
+            column: 9
+            line: 1
+          start:
+            column: 8
+            line: 1
+        local: 'a'
+        source: 'b'
+  statements: []
+\`;
+"
+`;
+
+exports[`named class 1`] = `
+"
+export class a {}
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -904,77 +945,25 @@ export {a}
         external: 'a'
         loc:
           end:
-            column: 9
+            column: 17
             line: 1
           start:
-            column: 8
+            column: 7
             line: 1
         local: 'a'
   imports: []
-  statements: []
+  statements:
+    - ClassDeclaration (1:7,1:17)
+        body: ClassBody (1:15,1:17)
+          body: []
+        id: Identifier (1:13,1:14)
+          name: 'a'
+        superClass: null
 \`;
 "
 `;
 
-exports[`13. named specifier multiple 1`] = `
-"
-export {a, b}
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'a'
-        loc:
-          end:
-            column: 9
-            line: 1
-          start:
-            column: 8
-            line: 1
-        local: 'a'
-    -
-        external: 'b'
-        loc:
-          end:
-            column: 12
-            line: 1
-          start:
-            column: 11
-            line: 1
-        local: 'b'
-  imports: []
-  statements: []
-\`;
-"
-`;
-
-exports[`14. named specifier renamed 1`] = `
-"
-export {a as b}
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'b'
-        loc:
-          end:
-            column: 14
-            line: 1
-          start:
-            column: 8
-            line: 1
-        local: 'a'
-  imports: []
-  statements: []
-\`;
-"
-`;
-
-exports[`15. named function 1`] = `
+exports[`named function 1`] = `
 "
 export function a() {}
 
@@ -1008,9 +997,9 @@ export function a() {}
 "
 `;
 
-exports[`16. named class 1`] = `
+exports[`named let 1`] = `
 "
-export class a {}
+export let a;
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -1020,7 +1009,7 @@ export class a {}
         external: 'a'
         loc:
           end:
-            column: 17
+            column: 13
             line: 1
           start:
             column: 7
@@ -1028,17 +1017,126 @@ export class a {}
         local: 'a'
   imports: []
   statements:
-    - ClassDeclaration (1:7,1:17)
-        body: ClassBody (1:15,1:17)
-          body: []
-        id: Identifier (1:13,1:14)
-          name: 'a'
-        superClass: null
+    - VariableDeclaration (1:11,1:12)
+        declarations:
+          - VariableDeclarator (1:11,1:12)
+              id: Identifier (1:11,1:12)
+                name: 'a'
+              init: null
+        kind: 'let'
 \`;
 "
 `;
 
-exports[`17. named var 1`] = `
+exports[`named renamed 1`] = `
+"
+import {a as b} from \\"c\\";
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports: []
+  imports:
+    -
+        external: 'a'
+        kind: 'value'
+        loc:
+          end:
+            column: 14
+            line: 1
+          start:
+            column: 8
+            line: 1
+        local: 'b'
+        source: 'c'
+  statements: []
+\`;
+"
+`;
+
+exports[`named specifier 1`] = `
+"
+export {a}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'a'
+        loc:
+          end:
+            column: 9
+            line: 1
+          start:
+            column: 8
+            line: 1
+        local: 'a'
+  imports: []
+  statements: []
+\`;
+"
+`;
+
+exports[`named specifier multiple 1`] = `
+"
+export {a, b}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'a'
+        loc:
+          end:
+            column: 9
+            line: 1
+          start:
+            column: 8
+            line: 1
+        local: 'a'
+    -
+        external: 'b'
+        loc:
+          end:
+            column: 12
+            line: 1
+          start:
+            column: 11
+            line: 1
+        local: 'b'
+  imports: []
+  statements: []
+\`;
+"
+`;
+
+exports[`named specifier renamed 1`] = `
+"
+export {a as b}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports:
+    -
+        external: 'b'
+        loc:
+          end:
+            column: 14
+            line: 1
+          start:
+            column: 8
+            line: 1
+        local: 'a'
+  imports: []
+  statements: []
+\`;
+"
+`;
+
+exports[`named var 1`] = `
 "
 export var a;
 
@@ -1069,7 +1167,7 @@ export var a;
 "
 `;
 
-exports[`18. named var multiple 1`] = `
+exports[`named var multiple 1`] = `
 "
 export var a, b;
 
@@ -1111,16 +1209,17 @@ export var a, b;
 "
 `;
 
-exports[`19. named let 1`] = `
+exports[`namespace 1`] = `
 "
-export let a;
+import * as a from \\"b\\";
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 \`
-  exports:
+  exports: []
+  imports:
     -
-        external: 'a'
+        kind: 'value'
         loc:
           end:
             column: 13
@@ -1129,199 +1228,100 @@ export let a;
             column: 7
             line: 1
         local: 'a'
+        source: 'b'
+  statements: []
+\`;
+"
+`;
+
+exports[`type alias 1`] = `
+"
+type a = {};
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports: []
   imports: []
   statements:
-    - VariableDeclaration (1:11,1:12)
+    - TypeAlias (1:0,1:12)
+        id: Identifier (1:5,1:6)
+          name: 'a'
+        right: ObjectTypeAnnotation (1:9,1:11)
+          callProperties: []
+          exact: false
+          indexers: []
+          properties: []
+        typeParameters: null
+\`;
+"
+`;
+
+exports[`variable 1`] = `
+"
+var a;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\`
+  exports: []
+  imports: []
+  statements:
+    - VariableDeclaration (1:4,1:5)
         declarations:
-          - VariableDeclarator (1:11,1:12)
-              id: Identifier (1:11,1:12)
+          - VariableDeclarator (1:4,1:5)
+              id: Identifier (1:4,1:5)
                 name: 'a'
               init: null
-        kind: 'let'
+        kind: 'var'
 \`;
 "
 `;
 
-exports[`20. from default 1`] = `
+exports[`variable multiple 1`] = `
 "
-export default from \\"b\\";
+var a, b;
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 \`
-  exports:
-    -
-        external: 'default'
-        loc:
-          end:
-            column: 14
-            line: 1
-          start:
-            column: 7
-            line: 1
-        local: 'default'
-        source: 'b'
+  exports: []
   imports: []
-  statements: []
+  statements:
+    - VariableDeclaration (1:4,1:5)
+        declarations:
+          - VariableDeclarator (1:4,1:5)
+              id: Identifier (1:4,1:5)
+                name: 'a'
+              init: null
+        kind: 'var'
+    - VariableDeclaration (1:7,1:8)
+        declarations:
+          - VariableDeclarator (1:7,1:8)
+              id: Identifier (1:7,1:8)
+                name: 'b'
+              init: null
+        kind: 'var'
 \`;
 "
 `;
 
-exports[`21. from default renamed 1`] = `
+exports[`while 1`] = `
 "
-export a from \\"b\\";
+while (a) {}
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 \`
-  exports:
-    -
-        external: 'a'
-        loc:
-          end:
-            column: 8
-            line: 1
-          start:
-            column: 7
-            line: 1
-        local: 'a'
-        source: 'b'
+  exports: []
   imports: []
-  statements: []
-\`;
-"
-`;
-
-exports[`22. from all 1`] = `
-"
-export * from \\"b\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        loc:
-          end:
-            column: 18
-            line: 1
-          start:
-            column: 0
-            line: 1
-        source: 'b'
-  imports: []
-  statements: []
-\`;
-"
-`;
-
-exports[`23. from named 1`] = `
-"
-export {a} from \\"b\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'a'
-        loc:
-          end:
-            column: 9
-            line: 1
-          start:
-            column: 8
-            line: 1
-        local: 'a'
-        source: 'b'
-  imports: []
-  statements: []
-\`;
-"
-`;
-
-exports[`24. from named multiple 1`] = `
-"
-export {a, b} from \\"b\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'a'
-        loc:
-          end:
-            column: 9
-            line: 1
-          start:
-            column: 8
-            line: 1
-        local: 'a'
-        source: 'b'
-    -
-        external: 'b'
-        loc:
-          end:
-            column: 12
-            line: 1
-          start:
-            column: 11
-            line: 1
-        local: 'b'
-        source: 'b'
-  imports: []
-  statements: []
-\`;
-"
-`;
-
-exports[`25. from named renamed 1`] = `
-"
-export {a as b} from \\"c\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'b'
-        loc:
-          end:
-            column: 14
-            line: 1
-          start:
-            column: 8
-            line: 1
-        local: 'a'
-        source: 'c'
-  imports: []
-  statements: []
-\`;
-"
-`;
-
-exports[`26. from named default renamed 1`] = `
-"
-export {default as a} from \\"b\\";
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-\`
-  exports:
-    -
-        external: 'a'
-        loc:
-          end:
-            column: 20
-            line: 1
-          start:
-            column: 8
-            line: 1
-        local: 'default'
-        source: 'b'
-  imports: []
-  statements: []
+  statements:
+    - WhileStatement (1:0,1:12)
+        body: BlockStatement (1:10,1:12)
+          body: []
+          directives: []
+        test: Identifier (1:7,1:8)
+          name: 'a'
 \`;
 "
 `;

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   },
   "devDependencies": {
     "ast-pretty-print": "^1.1.5",
-    "babel-plugin-tester": "^3.0.0",
-    "babylon-options": "^1.1.2",
+    "babel-core": "^6.26.0",
+    "babel-plugin-tester": "^5.0.0",
+    "babylon-options": "^2.0.1",
     "flow-bin": "^0.46.0",
     "jest": "^20.0.1"
   }


### PR DESCRIPTION
This is a prerequisite for upgrading this package to work with Babel 7. This is necessary because the new versions of these packages let us use new versions of `babel-core` and `babylon`. 